### PR TITLE
Fixing warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 # Cache directories and files
+doc
+examples/figures
 joblib
 .venv
 .pytest_cache

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -15,4 +15,17 @@ Functions
 .. autosummary::
    :toctree: generated/
 
-   desparsified_lasso
+   desparsified_lasso_confint
+   aggregate_medians
+   aggregate_quantiles
+   clustered_inference
+   design_matrix_toeplitz_cov
+   desparsified_lasso_confint
+   ensemble_clustered_inference
+   gaonkar
+   hd_inference
+   permutation_test
+   permutation_test_cv
+   reid
+   scenario
+   standardized_svr

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -9,11 +9,6 @@ Estimators
 
 .. currentmodule:: hidimstat
 
-.. autosummary::
-   :toctree: generated/
-
-   desparsified_lasso
-   
 Functions
 =========
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -61,8 +61,8 @@ templates_path = ['_templates']
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
-# source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ['.rst', '.md']
+# source_suffix = '.rst'
 
 # The master toctree document.
 master_doc = 'index'
@@ -194,7 +194,7 @@ texinfo_documents = [
 
 sphinx_gallery_conf = {
     'doc_module': ('hidimstat',),
-    'reference_url': dict(hidimstat=None),
+    # 'reference_url': dict(hidimstat=None),
     'examples_dirs': '../examples',
     'gallery_dirs': 'auto_examples',
     'reference_url': {

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -192,15 +192,29 @@ texinfo_documents = [
      'Miscellaneous'),
 ]
 
+# -- Intersphinx configuration -----------------------------------------------
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'numpy': ('https://numpy.org/devdocs', None),
+    'scipy': ('https://scipy.github.io/devdocs', None),
+    'matplotlib': ('https://matplotlib.org', None),
+    'sklearn': ('https://scikit-learn.org/stable', None),
+    'numba': ('https://numba.pydata.org/numba-doc/latest', None),
+    'joblib': ('https://joblib.readthedocs.io/en/latest', None),
+    'pandas': ('https://pandas.pydata.org/pandas-docs/stable', None),
+    'seaborn': ('https://seaborn.pydata.org/', None),
+}
+
 sphinx_gallery_conf = {
     'doc_module': ('hidimstat',),
-    # 'reference_url': dict(hidimstat=None),
+    'reference_url': dict(hidimstat=None),
     'examples_dirs': '../examples',
     'gallery_dirs': 'auto_examples',
-    'reference_url': {
-        'numpy': 'http://docs.scipy.org/doc/numpy-1.9.1',
-        'scipy': 'http://docs.scipy.org/doc/scipy-0.17.0/reference',
-    }
+    # 'reference_url': {
+    #     'numpy': 'http://docs.scipy.org/doc/numpy-1.9.1',
+    #     'scipy': 'http://docs.scipy.org/doc/scipy-0.17.0/reference',
+    # }
 }
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -5,52 +5,56 @@
 
 HiDimStat: High-dimensional statistical inference tool for Python
 =================================================================
-[![build][TravisCI]][travis]  [![coverage][CodeCov]][cov]
+|Build Status| |codecov|
 
 Installation
 ------------
 
 HiDimStat working only with Python 3, ideally Python 3.6+. For installation,
-run the following from terminal
+run the following from terminal::
 
-```bash
-git clone https://github.com/ja-che/hidimstat.git
-cd hidimstat
-pip install -e .
-# or python setup.py install
-```
+  git clone https://github.com/ja-che/hidimstat.git
+  cd hidimstat
+  pip install -e .
+  # or python setup.py install
+
 
 Dependencies
 ------------
 
-```
-joblib
-numpy
-scipy
-scikit-learn
-```
+hidimstat depends on the following packages::
 
-To run examples it is neccessary to install `matplotlib`, and to run tests it
-is also needed to install `pytest`.
+  joblib
+  numpy
+  scipy
+  scikit-learn
+
+
+To run examples it is neccessary to install ```matplotlib``, and to run tests it
+is also needed to install ``pytest``.
 
 
 Documentation & Examples
 ------------------------
 
 As of now in the `examples` folder there is a Python script to reproduce Figure
-1 in Nguyen et al. 2020 (see References below). __Warning__: this script
-should take quite a long time to run.
+1 in Nguyen et al. 2020 (see References below).
 
-```bash
-# Run this command in terminal
-python plot_fig_1_nguyen_et_al.py
-```
+.. warning::
+
+  this scrip should take quite a long time to run.
+
+.. code-block::
+
+  # Run this command in terminal
+  python plot_fig_1_nguyen_et_al.py
+
 
 References
 ----------
 
-Main references:
-
+Main references
+~~~~~~~~~~~~~~~
 
 Ensemble of Clustered desparsified Lasso (ECDL):
 
@@ -67,7 +71,8 @@ Aggregation of multiple Knockoffs (AKO):
 
 If you use our packages, we would appreciate citations to the aforementioned papers.
 
-#### Other useful references:
+Other useful references
+~~~~~~~~~~~~~~~~~~~~~~~
 
 For de-sparsified(or de-biased) Lasso:
 
@@ -89,13 +94,11 @@ For Knockoffs Inference:
   knockoffs for high dimensional controlled variable selection. Journal of the
   Royal Statistical Society Series B, 80(3), 551-577.
 
+.. |Build Status| image:: https://travis-ci.com/ja-che/hidimstat.svg?branch=master
+   :target: https://codecov.io/gh/ja-che/hidimstat
 
-[TravisCI]: https://travis-ci.com/ja-che/hidimstat.svg?branch=master "travisCI status"
-[travis]: https://travis-ci.com/ja-che/hidimstat
-
-[CodeCov]: https://codecov.io/gh/ja-che/hidimstat/branch/master/graph/badge.svg "CodeCov status"
-[cov]: https://codecov.io/gh/ja-che/hidimstat
-
+.. |codecov| image:: https://codecov.io/gh/ja-che/hidimstat/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/ja-che/hidimstat
 
 
 Build the documentation
@@ -103,7 +106,7 @@ Build the documentation
 
 To build the documentation you will need to run:
 
-::
+.. code-block::
 
     pip install -U sphinx_gallery sphinx_bootstrap_theme
     cd doc

--- a/examples/plot_fig_1_nguyen_et_al.py
+++ b/examples/plot_fig_1_nguyen_et_al.py
@@ -1,9 +1,14 @@
 # Authors: Binh Nguyen <tuan-binh.nguyen@inria.fr>
-"""Example: reproducing Figure 1 -- histogram of KO vs AKO performance -- in
-Nguyen et al. (2020) Aggregation of Multiple Knockoffs
-<https://arxiv.org/abs/2002.09269>
+"""
+histogram of KO vs AKO performance
+==================================
 
-To reduce the script runtime it is desirable to increase n_jobs parameter
+Example: reproducing Figure 1 in::
+
+    Nguyen et al. (2020) Aggregation of Multiple Knockoffs
+    https://arxiv.org/abs/2002.09269
+
+To reduce the script runtime it is desirable to increase n_jobs parameter.
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/plot_fig_1_nguyen_et_al.py
+++ b/examples/plot_fig_1_nguyen_et_al.py
@@ -82,14 +82,14 @@ def plot(results, n_simu, fdr):
 
 def main():
     # Simulation paramaters
-    n, p = 500, 1000
+    n, p = 50, 200
     snr = 3.0
     rho = 0.5
     sparsity = 0.06
     offset = 1
     fdr = 0.05
     gamma = 0.3
-    n_bootstraps = 25
+    n_bootstraps = 10
     n_simu = 10
     offset = 1
 

--- a/hidimstat/desparsified_lasso.py
+++ b/hidimstat/desparsified_lasso.py
@@ -47,25 +47,45 @@ def desparsified_lasso_confint(X, y, confidence=0.95, max_iter=5000,
 
     Parameters
     -----------
-        X : ndarray or scipy.sparse matrix, (n_samples, n_features)
-            Data
-        y : ndarray, shape (n_samples,) or (n_samples, n_targets)
-            Target. Will be cast to X's dtype if necessary
-        confidence : float, optional
-            Confidence level used to compute the confidence intervals.
-            Each value should be in the range [0, 1].
-        tol : float, optional
-            The tolerance for the optimization: if the updates are
-            smaller than ``tol``, the optimization code checks the
-            dual gap for optimality and continues until it is smaller
-            than ``tol``.
-        method : string, optional
-            The method for the nodewise lasso: "lasso" or "lasso_cv"
-        c : float, optional
-            Only used if method="lasso". Then alpha = c * alpha_max.
-        n_jobs : int or None, optional (default=1)
-            Number of CPUs to use during the cross validation.
-        """
+    X : ndarray or scipy.sparse matrix, (n_samples, n_features)
+        Data.
+
+    y : ndarray, shape (n_samples,) or (n_samples, n_targets)
+        Target. Will be cast to X's dtype if necessary.
+
+    confidence : float, optional
+        Confidence level used to compute the confidence intervals.
+        Each value should be in the range [0, 1].
+
+    max_iter : int, optional
+        The maximum number of iterations (subproblem definitions).
+
+    tol : float, optional
+        The tolerance for the optimization: if the updates are
+        smaller than ``tol``, the optimization code checks the
+        dual gap for optimality and continues until it is smaller
+        than ``tol``.
+
+    method : string, optional
+        The method for the nodewise lasso: "lasso" or "lasso_cv".
+
+    c : float, optional
+        Only used if method="lasso". Then alpha = c * alpha_max.
+
+    n_jobs : int or None, optional (default=1)
+        Number of CPUs to use during the cross validation.
+
+    Returns
+    -------
+    beta_hat : array, shape (n_features,)
+        Estimated parameter vector.
+
+    cb_min : array, shape (n_features)
+        Lower bound of the confidence intervals on the parameter vector.
+
+    cb_max : array, shape (n_features)
+        Upper bound of the confidence intervals on the parameter vector.
+    """
 
     X = np.asarray(X)
 

--- a/hidimstat/gaonkar.py
+++ b/hidimstat/gaonkar.py
@@ -6,16 +6,16 @@ def gaonkar(X, y, rcond=1e-3):
 
     Parameters
     -----------
-        X : ndarray or scipy.sparse matrix, (n_samples, n_features)
-            Data
-        y : ndarray, shape (n_samples,) or (n_samples, n_targets)
-            Target. Will be cast to X's dtype if necessary
-        rcond : float, optional
-            Cutoff for small singular values.
-            Singular values smaller (in modulus) than
-            `rcond` * largest_singular_value (again, in modulus)
-            are set to zero. Broadcasts against the stack of matrices
-        """
+    X : ndarray or scipy.sparse matrix, (n_samples, n_features)
+        Data
+    y : ndarray, shape (n_samples,) or (n_samples, n_targets)
+        Target. Will be cast to X's dtype if necessary
+    rcond : float, optional
+        Cutoff for small singular values.
+        Singular values smaller (in modulus) than
+        `rcond` * largest_singular_value (again, in modulus)
+        are set to zero. Broadcasts against the stack of matrices
+    """
 
     X = np.asarray(X)
     n_samples, n_features = X.shape

--- a/hidimstat/knockoffs/stat_coef_diff.py
+++ b/hidimstat/knockoffs/stat_coef_diff.py
@@ -2,10 +2,9 @@
 # Authors: Binh Nguyen <tuan-binh.nguyen@inria.fr>
 
 import numpy as np
-from sklearn.linear_model import (ElasticNetCV, LassoCV, LogisticRegressionCV,
-                                  RidgeCV)
-from sklearn.linear_model._coordinate_descent import _alpha_grid
-from sklearn.model_selection import GridSearchCV
+from sklearn.linear_model import (LassoCV, LogisticRegressionCV)
+# from sklearn.linear_model._coordinate_descent import _alpha_grid
+# from sklearn.model_selection import GridSearchCV
 
 
 def stat_coef_diff(X, X_tilde, y, method='lasso_cv', cv=5, n_jobs=1,
@@ -55,7 +54,7 @@ def stat_coef_diff(X, X_tilde, y, method='lasso_cv', cv=5, n_jobs=1,
     coef: 1D ndarray (n_features * 2, )
         coefficients of the estimation problem
     """
-    
+
     n_features = X.shape[1]
     X_ko = np.column_stack([X, X_tilde])
     lambda_max = np.max(np.dot(X_ko.T, y)) / (2 * n_features)

--- a/hidimstat/noise_std.py
+++ b/hidimstat/noise_std.py
@@ -8,22 +8,22 @@ def reid(X, y, method="lars", tol=1e-4, max_iter=1e+3, n_jobs=1):
 
     Parameters
     -----------
-        X : ndarray or scipy.sparse matrix, (n_samples, n_features)
-            Data
-        y : ndarray, shape (n_samples,) or (n_samples, n_targets)
-            Target. Will be cast to X's dtype if necessary
-        method : string, optional
-            The method for the CV-lasso: "lars" or "lasso"
-        tol : float, optional
-            The tolerance for the optimization: if the updates are
-            smaller than ``tol``, the optimization code checks the
-            dual gap for optimality and continues until it is smaller
-            than ``tol``.
-        max_iter : int, optional
-            The maximum number of iterations
-        n_jobs : int or None, optional (default=1)
-            Number of CPUs to use during the cross validation.
-        """
+    X : ndarray or scipy.sparse matrix, (n_samples, n_features)
+        Data
+    y : ndarray, shape (n_samples,) or (n_samples, n_targets)
+        Target. Will be cast to X's dtype if necessary
+    method : string, optional
+        The method for the CV-lasso: "lars" or "lasso"
+    tol : float, optional
+        The tolerance for the optimization: if the updates are
+        smaller than ``tol``, the optimization code checks the
+        dual gap for optimality and continues until it is smaller
+        than ``tol``.
+    max_iter : int, optional
+        The maximum number of iterations
+    n_jobs : int or None, optional (default=1)
+        Number of CPUs to use during the cross validation.
+    """
 
     X = np.asarray(X)
     n_samples, n_features = X.shape

--- a/hidimstat/scenario.py
+++ b/hidimstat/scenario.py
@@ -7,12 +7,12 @@ def design_matrix_toeplitz_cov(seed=0, n=100, p=500, rho=0.0):
 
     Parameters
     -----------
-        n : int
-            Number of samples
-        p : int
-            Number of features
-        rho: float
-            Level of correlation between neighboring features
+    n : int
+        Number of samples
+    p : int
+        Number of features
+    rho: float
+        Level of correlation between neighboring features
     """
 
     np.random.seed(seed)
@@ -35,30 +35,30 @@ def scenario(scenario='Toeplitz', seed=0, n_samples=100, n_features=500,
 
     Parameters
     -----------
-        scenario : string
-            Type of scenario generated
-        n_samples : int
-            Number of samples
-        n_features : int
-            Number of features
-        effect_small : float
-            Value of the low non zero coefficients of the weight vector
-        effect_medium : float
-            Value of the medium non zero coefficients of the weight vector
-        effect_large : float
-            Value of the high non zero coefficients of the weight vector
-        effect_s_nb : int
-            Number of coefficients with a low non zero value
-        effect_m_nb : int
-            Number of coefficients with a medium non zero value
-        effect_l_nb : int
-            Number of coefficients with a high non zero value
-        sigma: float
-            Standard deviation of the additive White Gaussian noise
-        rho: float
-            Level of correlation between neighboring features
-        shuffle : boolean
-            Shuffle the features (changing data structure) if True.
+    scenario : string
+        Type of scenario generated
+    n_samples : int
+        Number of samples
+    n_features : int
+        Number of features
+    effect_small : float
+        Value of the low non zero coefficients of the weight vector
+    effect_medium : float
+        Value of the medium non zero coefficients of the weight vector
+    effect_large : float
+        Value of the high non zero coefficients of the weight vector
+    effect_s_nb : int
+        Number of coefficients with a low non zero value
+    effect_m_nb : int
+        Number of coefficients with a medium non zero value
+    effect_l_nb : int
+        Number of coefficients with a high non zero value
+    sigma: float
+        Standard deviation of the additive White Gaussian noise
+    rho: float
+        Level of correlation between neighboring features
+    shuffle : boolean
+        Shuffle the features (changing data structure) if True.
     """
 
     if scenario == 'Toeplitz':


### PR DESCRIPTION
I am trying to fix two warnings when I build the github pages (`make html`):

1/

> WARNING: error while formatting arguments for hidimstat.desparsified_lasso: module 'hidimstat.desparsified_lasso' has no attribute '\_\_mro\_\_'

2/

> /home/jerome/hidimstat/doc/auto_examples/index.rst:27: WARNING: undefined label: sphx_glr_auto_examples_plot_fig_1_nguyen_et_al.py (if the link has no caption the label must precede a section header)
> /home/jerome/hidimstat/doc/auto_examples/sg_execution_times.rst:12: WARNING: undefined label: sphx_glr_auto_examples_plot_fig_1_nguyen_et_al.py (if the link has no caption the label must precede a section header)

@agramfort can you help ?

I believe 1/ is due to fact that sphinx sees 'desparsified_lasso' method as a class , however I do not find the fix.
Also, concerning 2/, doc/auto_examples/index.rst is automatically generated, again I do not know how to fix this.